### PR TITLE
move call of xf86CrtcScreenInit before ARMSOCEnterVT

### DIFF
--- a/src/armsoc_driver.c
+++ b/src/armsoc_driver.c
@@ -1131,6 +1131,9 @@ ARMSOCScreenInit(SCREEN_INIT_ARGS_DECL)
 	 */
 	pScrn->vtSema = TRUE;
 
+	/* Do some XRandR initialization. Return value is not useful */
+	(void)xf86CrtcScreenInit(pScreen);
+
 	/* Take over the virtual terminal from the console, set the
 	 * desired mode, etc.:
 	 */
@@ -1138,9 +1141,6 @@ ARMSOCScreenInit(SCREEN_INIT_ARGS_DECL)
 		ERROR_MSG("ARMSOCEnterVT() failed!");
 		goto fail6;
 	}
-
-	/* Do some XRandR initialization. Return value is not useful */
-	(void)xf86CrtcScreenInit(pScreen);
 
 	if (!miCreateDefColormap(pScreen)) {
 		ERROR_MSG("Cannot create colormap!");


### PR DESCRIPTION
With Xorg 1.20 and randr leasing, calls to xf86SetDesiredModes() now
rely on crtcs being initialized beforehand.